### PR TITLE
fix(proxy):remove useless base_url

### DIFF
--- a/web/src/restful/api.js
+++ b/web/src/restful/api.js
@@ -140,7 +140,7 @@ export const updateTree = (url, params) => {
 };
 
 export const uploadFile = url => {
-    return baseUrl + '/api/fastrunner/file/?token=' + store.token
+    return '/api/fastrunner/file/?token=' + store.token
 };
 
 export const addAPI = params => {


### PR DESCRIPTION
bug:base_url can't be found
Scope of impact: api template, request key and form fields in request are not displayed