### PR TITLE
hotfix:修复配置管理-新增配置填写Header、Variables时，配置名称和请求地址会自动清空的问题

### DIFF
--- a/web/src/pages/fastrunner/config/RecordConfig.vue
+++ b/web/src/pages/fastrunner/config/RecordConfig.vue
@@ -92,8 +92,10 @@ export default {
             set(value) {
                 this.addConfigActivate = value;
                 this.respConfig = {
+                    id: "",
+                    name: "",
+                    base_url: "",
                     is_default: false,
-                    id: '',
                     body: {
                         name: '',
                         base_url: '',

--- a/web/src/pages/fastrunner/config/components/ConfigBody.vue
+++ b/web/src/pages/fastrunner/config/components/ConfigBody.vue
@@ -118,14 +118,11 @@ export default {
         }
     },
     watch: {
-        response: {
-            deep: true,
-            handler(val) {
-                this.name = val.body.name;
-                this.baseUrl = val.body.base_url;
-                this.id = val.id;
-                this.is_default = val.is_default
-            }
+        response() {
+            this.id = this.response.id;
+            this.name = this.response.name;
+            this.baseUrl = this.response.base_url;
+            this.is_default = this.response.is_default;
         }
     },
     methods: {


### PR DESCRIPTION
<img width="1009" alt="image" src="https://github.com/lihuacai168/AnotherFasterRunner/assets/37645552/061a6db2-3bc1-419e-b6af-df994521a7ec">
