### PR TITLE
feat: Upgrade Node.js from version 16 to 22

### DIFF
--- a/.github/workflows/web_deploy.yml
+++ b/.github/workflows/web_deploy.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '22'
     - name: Install npm dependencies
       run: yarn install
     - name: Run build task

--- a/web/Dockerfile-build
+++ b/web/Dockerfile-build
@@ -1,4 +1,4 @@
-FROM node:16 as build-stage
+FROM node:22 as build-stage
 
 # make the 'app' folder the current working directory
 WORKDIR /app

--- a/web/package.json
+++ b/web/package.json
@@ -71,8 +71,8 @@
     "zip-webpack-plugin": "^2.0.0"
   },
   "engines": {
-    "node": ">= 6.0.0",
-    "npm": ">= 3.0.0"
+    "node": ">= 22.0.0",
+    "npm": ">= 10.0.0"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
## Summary
- Upgrade Node.js from version 16 to version 22 for better performance and security
- Update all Node.js references in Docker, package.json, and GitHub Actions
- Successfully tested the build with Node.js 22

## Changes
- Updated `web/Dockerfile-build` to use `node:22`
- Updated `web/package.json` engines field to require Node.js >= 22.0.0 and npm >= 10.0.0
- Updated `.github/workflows/web_deploy.yml` to use Node.js 22

## Test plan
- [x] Local build tested successfully with Node.js 22
- [ ] CI/CD pipeline verification
- [ ] Docker build verification
- [ ] Production deployment verification

🤖 Generated with [Claude Code](https://claude.ai/code)